### PR TITLE
perf: `useFsHandleStorage` has poor perf when using device's local file

### DIFF
--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -34,7 +34,8 @@ document.querySelector('.main')?.addEventListener('click', async () => {
     // db = await initSQLite(useIdbStorage('test.db', { url }))
   }
   await runSQL(db.run)
-  await runSQL((await initSQLite(useMemoryStorage({ url: syncUrl }))).run)
+  // await runSQL((await initSQLite(useMemoryStorage({ url: syncUrl }))).run)
+  await db.close()
 })
 document.querySelector('.import')?.addEventListener('click', async () => {
   await db?.close()

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -29,6 +29,7 @@ document.querySelector('.main')?.addEventListener('click', async () => {
   if (!db) {
     // @ts-expect-error no types
     const root = await window.showDirectoryPicker()
+    // const root = await navigator.storage.getDirectory()
     // db = await initSQLite(useIdbMemoryStorage('test.db', { url }))
     db = await initSQLite(useFsHandleStorage('test.db', root, { url }))
     // db = await initSQLite(useIdbStorage('test.db', { url }))
@@ -146,7 +147,7 @@ document.querySelector('.importW')?.addEventListener('click', async () => {
   }
 })
 document.querySelector('.clear')?.addEventListener('click', async () => {
-  await db?.close()
+  await db?.close().catch()
   const root = await navigator.storage.getDirectory()
   for await (const [name] of root.entries()) {
     await root.removeEntry(name, { recursive: true })

--- a/src/vfs/class/OPFSAnyContextVFS.js
+++ b/src/vfs/class/OPFSAnyContextVFS.js
@@ -159,10 +159,13 @@ export class OPFSAnyContextVFS extends WebLocksMixin(FacadeVFS) {
     try {
       const file = this.mapIdToFile.get(fileId)
 
+      console.time('[read]')
       if (file.writable) {
+        console.timeLog('[read]', 'start close writable')
         await file.writable.close()
         file.writable = null
         file.blob = null
+        console.timeLog('[read]', 'end close writable')
       }
       if (!file.blob) {
         file.blob = await file.fileHandle.getFile()
@@ -177,8 +180,10 @@ export class OPFSAnyContextVFS extends WebLocksMixin(FacadeVFS) {
 
       if (bytesRead < pData.byteLength) {
         pData.fill(0, bytesRead)
+        console.timeEnd('[read]')
         return VFS.SQLITE_IOERR_SHORT_READ
       }
+      console.timeEnd('[read]')
       return VFS.SQLITE_OK
     } catch (e) {
       this.lastError = e
@@ -196,13 +201,14 @@ export class OPFSAnyContextVFS extends WebLocksMixin(FacadeVFS) {
     try {
       const file = this.mapIdToFile.get(fileId)
 
+      console.time('[write]')
       if (!file.writable) {
         file.writable = await file.fileHandle.createWritable({ keepExistingData: true })
       }
       await file.writable.seek(iOffset)
       await file.writable.write(pData.subarray())
       file.blob = null
-
+      console.timeEnd('[write]')
       return VFS.SQLITE_OK
     } catch (e) {
       this.lastError = e


### PR DESCRIPTION
![PixPin_2024-12-27_15-45-30](https://github.com/user-attachments/assets/61f759d3-ad81-446a-aad3-ea35b388c0ce)

Run with `window.showDirectoryPicker()` on Windows 11

When call `jRead`, the `writable` will be closed if present, which will cause a long time.